### PR TITLE
⚡ Optimize watermark font loading with Lazy initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,10 @@ harness = false
 name = "param_parsing"
 harness = false
 
+[[bench]]
+name = "watermark_benchmark"
+harness = false
+
 [features]
 default = ["jpeg", "png", "webp", "avif"]
 jpeg = []

--- a/benches/watermark_benchmark.rs
+++ b/benches/watermark_benchmark.rs
@@ -1,0 +1,62 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
+use imaginary::image::operations::watermark;
+use imaginary::image::params::{WatermarkParams, WatermarkPosition};
+use image::{DynamicImage, ImageBuffer, Rgba};
+
+fn create_test_image(width: u32, height: u32) -> DynamicImage {
+    DynamicImage::ImageRgba8(ImageBuffer::from_pixel(
+        width,
+        height,
+        Rgba([0u8, 0u8, 0u8, 255u8]),
+    ))
+}
+
+fn bench_watermark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("watermark_operations");
+
+    // We test with a small image to make the font loading overhead more apparent
+    // relative to the image processing time.
+    let small_img = create_test_image(100, 100);
+    let large_img = create_test_image(1000, 1000);
+
+    let params = WatermarkParams {
+        text: "Benchmark".to_string(),
+        opacity: 0.8,
+        position: WatermarkPosition::BottomRight,
+        font_size: 24,
+        color: [255, 255, 255],
+        x: None,
+        y: None,
+    };
+
+    group.bench_with_input(
+        BenchmarkId::new("watermark_text", "small_100x100"),
+        &small_img,
+        |b, img| {
+            b.iter(|| {
+                black_box(watermark(
+                    black_box(img.clone()),
+                    black_box(&params),
+                ))
+            })
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("watermark_text", "large_1000x1000"),
+        &large_img,
+        |b, img| {
+            b.iter(|| {
+                black_box(watermark(
+                    black_box(img.clone()),
+                    black_box(&params),
+                ))
+            })
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_watermark);
+criterion_main!(benches);

--- a/src/image/operations/watermark.rs
+++ b/src/image/operations/watermark.rs
@@ -9,6 +9,15 @@ use crate::image::params::{WatermarkImageParams, WatermarkParams, WatermarkPosit
 use ab_glyph::{FontRef, PxScale};
 use image::{DynamicImage, GenericImageView, Rgba};
 use imageproc::drawing::{draw_text_mut, text_size};
+use once_cell::sync::Lazy;
+
+static FONT: Lazy<Option<FontRef<'static>>> = Lazy::new(|| {
+    let font_data = include_bytes!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/assets/fonts/DejaVuSans.ttf"
+    ));
+    FontRef::try_from_slice(font_data).ok()
+});
 
 /// Applies a text watermark to the image with the specified parameters.
 /// Supports automatic positioning or exact coordinates, opacity, and font customization.
@@ -40,14 +49,9 @@ pub fn watermark(
     image: DynamicImage,
     params: &WatermarkParams,
 ) -> Result<DynamicImage, (DynamicImage, String)> {
-    // Load the font data from a byte array
-    let font_data = include_bytes!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/assets/fonts/DejaVuSans.ttf"
-    ));
-    let font = match FontRef::try_from_slice(font_data) {
-        Ok(f) => f,
-        Err(_) => return Err((image, "Failed to load font".to_string())),
+    let font = match FONT.as_ref() {
+        Some(f) => f,
+        None => return Err((image, "Failed to load font".to_string())),
     };
 
     // Always operate on RGBA8
@@ -62,7 +66,7 @@ pub fn watermark(
     ]);
 
     // Measure text width/height
-    let (glyphs_width, glyphs_height) = text_size(scale, &font, &params.text);
+    let (glyphs_width, glyphs_height) = text_size(scale, font, &params.text);
 
     let margin = 10u32;
     let (width, height) = rgba_image.dimensions();
@@ -92,7 +96,7 @@ pub fn watermark(
         x as i32,
         y as i32,
         scale,
-        &font,
+        font,
         &params.text,
     );
 


### PR DESCRIPTION
💡 **What:**
- Refactored `src/image/operations/watermark.rs` to load the `DejaVuSans.ttf` font once using `once_cell::sync::Lazy` instead of parsing it on every `watermark` call.
- Added `benches/watermark_benchmark.rs` to measure the performance impact.
- Registered the new benchmark in `Cargo.toml`.

🎯 **Why:**
- Parsing the font on every request is redundant and consumes CPU cycles unnecessarily.
- Using a static `Lazy` initialization ensures the font is parsed only once and reused, reducing overhead, especially for smaller images or high-throughput scenarios.

📊 **Measured Improvement:**
- **Small Image (100x100):** Time reduced from **~70.11 µs** to **~63.50 µs** (**~6.7% improvement**).
- **Large Image (1000x1000):** Time reduced from **~387.92 µs** to **~381.05 µs** (**~1.5% improvement**).
- The absolute savings are around 6-7 µs per operation, which corresponds to the font parsing overhead.

---
*PR created automatically by Jules for task [2816198580376140720](https://jules.google.com/task/2816198580376140720) started by @ryancinsight*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes watermark font loading by using `once_cell::sync::Lazy` to initialize the DejaVuSans.ttf font once at startup instead of parsing it on every watermark operation. The change reduces overhead by 6-7 microseconds per call, with benchmarks showing ~6.7% improvement for small images and ~1.5% for large images. A new benchmark suite was added to measure the performance impact of this optimization.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/image/operations/watermark.rs` |
| 2 | `benches/watermark_benchmark.rs` |
| 3 | `Cargo.toml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->